### PR TITLE
Fix Hoodlums' Revenge save file parsing and progression

### DIFF
--- a/src/RayCarrot.RCP.Metro/Binary/Gba/RHR/RHR_LevelSave.cs
+++ b/src/RayCarrot.RCP.Metro/Binary/Gba/RHR/RHR_LevelSave.cs
@@ -5,14 +5,14 @@ namespace RayCarrot.RCP.Metro;
 
 public class RHR_LevelSave : BinarySerializable
 {
-    public short Score { get; set; }
+    public ushort Score { get; set; }
     public byte Lums { get; set; }
     public RHR_LevelSaveFlags Flags { get; set; }
     public byte Teensies { get; set; }
 
     public override void SerializeImpl(SerializerObject s)
     {
-        Score = s.Serialize<short>(Score, name: nameof(Score));
+        Score = s.Serialize<ushort>(Score, name: nameof(Score));
         Lums = s.Serialize<byte>(Lums, name: nameof(Lums));
 
         s.DoBits<byte>(b =>

--- a/src/RayCarrot.RCP.Metro/Games/Progression/Games/Gba/GameProgressionManager_RaymanHoodlumsRevenge_Gba.cs
+++ b/src/RayCarrot.RCP.Metro/Games/Progression/Games/Gba/GameProgressionManager_RaymanHoodlumsRevenge_Gba.cs
@@ -115,7 +115,7 @@ public class GameProgressionManager_RaymanHoodlumsRevenge_Gba : EmulatedGameProg
         new(99, 4, 7000,  14000, 19000, true,  false), // Clearleaf Falls
         new(2,  0, 0,     0,     0,     false, false), // Infernal Machine
         new(75, 0, 5000,  11000, 16000, true,  false), // Dungeon of Murk
-        new(76, 0, 11000, 18000, 26000, true,  false), // Bog of Murk
+        new(76, 6, 11000, 18000, 26000, true,  false), // Bog of Murk
         new(4,  0, 0,     0,     0,     false, false), // Begoniax Bayou
         new(58, 4, 7000,  12000, 21000, true,  false), // Rivers of Murk
         new(96, 4, 10000, 22000, 30000, true,  false), // Hoodlum Moor


### PR DESCRIPTION
- Level score is unsigned, not signed
- Bog of Murk has 6 Teensies, not 0